### PR TITLE
do not overrun when quotes are unescaped

### DIFF
--- a/csv.h
+++ b/csv.h
@@ -786,7 +786,7 @@ namespace io{
                                         --col_end;
                                         char*out = col_begin;
                                         for(char*in = col_begin; in!=col_end; ++in){
-                                                if(*in == quote && *(in+1) == quote){
+                                                if(*in == quote && (in+1) != col_end && *(in+1) == quote){
                                                          ++in;
                                                 }
                                                 *out = *in;


### PR DESCRIPTION
When using double_quotes_escape, an unescaped quote can lead to an overrun if it appears at the end of the string.

For example, with the following code(test.cpp):

```
#include <iostream>
#include "csv.h"

int main(){
  io::CSVReader<3, io::trim_chars<' ', '\t'>, io::double_quote_escape<',', '\"'>> in("test.csv");
  in.read_header(io::ignore_extra_column, "vendor", "size", "speed");
  std::string vendor; int size; double speed;
  while(in.read_row(vendor, size, speed)){
    std::cout << "Vendor: " << vendor
              << ", size: " << size
              <<", speed: " << speed
              << std::endl;
    // do stuff with the data
  }
}

```

And the following csv file(test.csv):
```
"vendor","size","speed"
"escaped ""quotes""","1","2"
"unescaped "quotes"","1","2"
```

I get:
```
$ clang++ -std=c++11 test.cpp -lpthread -o test && ./test
Vendor: escaped "quotes", size: 1, speed: 2
Segmentation fault (core dumped)
```

With the proposed fix:
```
$ clang++ -std=c++11 test.cpp -lpthread -o test && ./test
Vendor: escaped "quotes", size: 1, speed: 2
Vendor: unescaped "quotes", size: 1, speed: 2
```