### PR TITLE
remove unused parameter (and its warning)

### DIFF
--- a/csv.h
+++ b/csv.h
@@ -1073,7 +1073,7 @@ namespace io{
                 template<class overflow_policy> void parse(char*col, long double&x) { parse_float(col, x); }
 
                 template<class overflow_policy, class T>
-                void parse(char*col, T&x){
+                void parse(char*, T&){
                         // GCC evalutes "false" when reading the template and
                         // "sizeof(T)!=sizeof(T)" only when instantiating it. This is why
                         // this strange construct is used.


### PR DESCRIPTION
clang 5.0 with -Wunused-parameter produced the following warning:

../external/csv/fast-cpp-csv-parser/csv.h:1076:33: warning: unused parameter 'col' [-Wunused-parameter]
                void parse(char*col, T&x){
                                ^
../external/csv/fast-cpp-csv-parser/csv.h:1076:40: warning: unused parameter 'x' [-Wunused-parameter]
                void parse(char*col, T&x){
                                       ^
This patches fixes it.

Seen with clang 5.0.0-svn294894-1