### PR TITLE
increase size of error_message_buffer to make gcc7 not warn with "-Wformat-truncation"

### DIFF
--- a/csv.h
+++ b/csv.h
@@ -63,7 +63,7 @@ namespace io{
                                 return error_message_buffer;
                         }
 
-                        mutable char error_message_buffer[256];
+                        mutable char error_message_buffer[512];
                 };
 
                 const int max_file_name_length = 255;


### PR DESCRIPTION
Buffer seems to be too small, at least according to gcc7