### PR TITLE
Fix unused variable compiler warning

### DIFF
--- a/csv.h
+++ b/csv.h
@@ -1074,6 +1074,9 @@ namespace io{
 
                 template<class overflow_policy, class T>
                 void parse(char*col, T&x){
+                        // Mute unused variable compiler warning
+                        (void)col;
+                        (void)x;
                         // GCC evalutes "false" when reading the template and
                         // "sizeof(T)!=sizeof(T)" only when instantiating it. This is why
                         // this strange construct is used.


### PR DESCRIPTION
I'm using fast-cpp-csv-parser in a project which I compile with `-Wall` & `-Wextra` and I get a `-Wunused-parameter` warning. This is an easy fix for that, since only the types are required by the actual implementation.