### PR TITLE
warning-fix: remove 'unnecessary parentheses'-warning

### DIFF
--- a/csv.h
+++ b/csv.h
@@ -1112,7 +1112,7 @@ namespace io{
         private:
                 LineReader in;
 
-                char*(row[column_count]);
+                char*row[column_count];
                 std::string column_names[column_count];
 
                 std::vector<int>col_order;

--- a/csv.h
+++ b/csv.h
@@ -70,13 +70,13 @@ namespace io{
 
                 struct with_file_name{
                         with_file_name(){
-                                std::memset(file_name, 0, max_file_name_length+1);
+                                std::memset(file_name, 0, sizeof(file_name));
                         }
                        
                         void set_file_name(const char*file_name){
                                 if(file_name != nullptr){
-                                        strncpy(this->file_name, file_name, error::max_file_name_length);
-                                        this->file_name[error::max_file_name_length] = '\0';
+                                        strncpy(this->file_name, file_name, sizeof(this->file_name));
+                                        this->file_name[sizeof(this->file_name)-1] = '\0';
                                 }else{
                                         this->file_name[0] = '\0';
                                 }
@@ -422,8 +422,8 @@ namespace io{
 
                 void set_file_name(const char*file_name){
                         if(file_name != nullptr){
-                                strncpy(this->file_name, file_name, error::max_file_name_length);
-                                this->file_name[error::max_file_name_length] = '\0';
+                                strncpy(this->file_name, file_name, sizeof(this->file_name));
+                                this->file_name[sizeof(this->file_name)-1] = '\0';
                         }else{
                                 this->file_name[0] = '\0';
                         }


### PR DESCRIPTION
GCC 8.2 warns:

    csv.h:1099:22: warning: unnecessary parentheses in declaration of ‘row’ [-Wparentheses]

This commit fixes it.