### PR TITLE
Safer EOF condition in next_line()

### DIFF
--- a/csv.h
+++ b/csv.h
@@ -442,7 +442,7 @@ namespace io{
                 }
 
                 char*next_line(){
-                        if(data_begin == data_end)
+                        if(data_begin >= data_end)
                                 return 0;
 
                         ++file_line;


### PR DESCRIPTION
I think there's a bug here. `data_begin` can sometimes be greater than `data_end`. When this happens, it will read the "line" beyond the allocated memory. I was getting "too few columns" error because of this.

I don't know exactly what's going on, but in at least one case, I confirmed this happens right before line 445:

data_begin=161731
data_end=161730

I think it has something to do with the file not ending with a newline character. Line 467 doesn't seem to handle it correctly for some reason.

And it doesn't always happen given the same file. It seems to depend on the state of the rest of the application somehow. Threading was turned off.

It's probably better to fix whatever caused this problem, but for now, I think this `>=` check fixes it; probably safer this way anyway.