### PR TITLE
fix buffer overrun (and corresponding g++ warning message)

### DIFF
--- a/csv.h
+++ b/csv.h
@@ -422,7 +422,7 @@ namespace io{
 
                 void set_file_name(const char*file_name){
                         if(file_name != nullptr){
-                                strncpy(this->file_name, file_name, sizeof(this->file_name));
+                                strncpy(this->file_name, file_name, sizeof(this->file_name)-1);
                                 this->file_name[sizeof(this->file_name)-1] = '\0';
                         }else{
                                 this->file_name[0] = '\0';


### PR DESCRIPTION
Fixes compiler warning "specified bound 256 equals destination size [-Wstringop-truncation]"