### PR TITLE
Silence double to float truncation VS warnings

### DIFF
--- a/csv.h
+++ b/csv.h
@@ -1058,10 +1058,10 @@ namespace io{
                                 if(e != 0){
                                         T base;
                                         if(e < 0){
-                                                base = 0.1;
+                                                base = T(0.1);
                                                 e = -e;
                                         }else{
-                                                base = 10;
+                                                base = T(10);
                                         }
        
                                         while(e != 1){


### PR DESCRIPTION
When loading float values, Visual Studio generates a warning :
`Q:\Code\csv-reader\csv\csv.h(1061): warning C4305: '=': truncation from 'double' to 'float'`.
This is averted by explicitly typing the literal values.