### PR TITLE
allow '\0' '\n' in quoted columns

### DIFF
--- a/csv.h
+++ b/csv.h
@@ -49,10 +49,33 @@
 #include <cerrno>
 #include <istream>
 
+
+
 namespace io{
         ////////////////////////////////////////////////////////////////////////////
         //                                 LineReader                             //
         ////////////////////////////////////////////////////////////////////////////
+
+        template<char sep, bool null_terminated = true>
+        struct no_quote_escape {
+            static bool hasQuote() {
+                return false;
+            }
+            static char getQuoteChar() {
+                return '\0';
+            }
+            static const char*find_next_column_end(const char*col_begin) {
+                while (*col_begin != sep && (*col_begin != '\0'))
+                    ++col_begin;
+                return col_begin;
+            }
+
+            static void unescape(char*&, char*&) {
+
+            }
+
+        };
+
 
         namespace error{
                 struct base : std::exception{
@@ -153,7 +176,7 @@ namespace io{
                         }
 
                         int read(char*buffer, int size){
-                                return std::fread(buffer, 1, size, file);
+                                return (int)std::fread(buffer, 1, size, file);
                         }
 
                         ~OwningStdIOByteSourceBase(){
@@ -170,7 +193,7 @@ namespace io{
 
                         int read(char*buffer, int size){
                                 in.read(buffer, size);
-                                return in.gcount();
+                                return (int)in.gcount();
                         }
 
                         ~NonOwningIStreamByteSource(){}
@@ -186,7 +209,7 @@ namespace io{
                         int read(char*buffer, int desired_byte_count){
                                 int to_copy_byte_count = desired_byte_count;
                                 if(remaining_byte_count < to_copy_byte_count)
-                                        to_copy_byte_count = remaining_byte_count;
+                                        to_copy_byte_count = (int)remaining_byte_count;
                                 std::memcpy(buffer, str, to_copy_byte_count);
                                 remaining_byte_count -= to_copy_byte_count;
                                 str += to_copy_byte_count;
@@ -314,7 +337,7 @@ namespace io{
                         int desired_byte_count;
                 };
         }
-
+		template<class quote_policy = no_quote_escape<','>>
         class LineReader{
         private:
                 static const int block_len = 1<<20;
@@ -326,6 +349,9 @@ namespace io{
                 #endif
                 int data_begin;
                 int data_end;
+
+				bool hasQuote;
+				char quoteChar;
 
                 char file_name[error::max_file_name_length+1];
                 unsigned file_line;
@@ -346,6 +372,9 @@ namespace io{
 
                 void init(std::unique_ptr<ByteSourceBase>byte_source){
                         file_line = 0;
+
+						hasQuote = quote_policy::hasQuote();
+						quoteChar = quote_policy::getQuoteChar();
 
                         buffer = std::unique_ptr<char[]>(new char[3*block_len]);
                         data_begin = 0;
@@ -462,9 +491,14 @@ namespace io{
                                 }
                         }
 
+						bool quoted_data = false;
                         int line_end = data_begin;
-                        while(buffer[line_end] != '\n' && line_end != data_end){
+                        while( (quoted_data || buffer[line_end] != '\n') && line_end != data_end){
+							if (hasQuote && buffer[line_end] == quoteChar) {
+								quoted_data = !quoted_data;
+							}
                                 ++line_end;
+
                         }
 
                         if(line_end - data_begin + 1 > block_len){
@@ -753,30 +787,26 @@ namespace io{
                 }
         };
 
-        template<char sep>
-        struct no_quote_escape{
-                static const char*find_next_column_end(const char*col_begin){
-                        while(*col_begin != sep && *col_begin != '\0')
-                                ++col_begin;
-                        return col_begin;
-                }
+        
 
-                static void unescape(char*&, char*&){
-
-                }
-        };
-
-        template<char sep, char quote>
+        template<char sep, char quote, bool null_terminated = true>
         struct double_quote_escape{
+				static bool hasQuote() {
+					return true;
+				}
+				static char getQuoteChar() {
+					return quote;
+				}
+
                 static const char*find_next_column_end(const char*col_begin){
-                        while(*col_begin != sep && *col_begin != '\0')
+                        while(*col_begin != sep && ( *col_begin != '\0'))
                                 if(*col_begin != quote)
                                         ++col_begin;
                                 else{
                                         do{
                                                 ++col_begin;
                                                 while(*col_begin != quote){
-                                                        if(*col_begin == '\0')
+                                                        if(( null_terminated && *col_begin == '\0'))
                                                                 throw error::escaped_string_not_closed();
                                                         ++col_begin;
                                                 }
@@ -1110,7 +1140,7 @@ namespace io{
         >
         class CSVReader{
         private:
-                LineReader in;
+                LineReader<quote_policy> in;
 
                 char*row[column_count];
                 std::string column_names[column_count];


### PR DESCRIPTION
1. main addition is templating LineReader to allow it the following functionality: next_line() will stop on the first end_line char it finds. this is not ideal since quoted column may include a line_end char which will make the new_line() return prematurely. in addition, find_next_column_end() will return prematurely as will if it encounters a null-char inside a quoted column. my usage of this parser happens to include both end-line and null chars (and other non-ascii chars) inside quoted columns and I had to add those changes to make it work. I added a template argument [null_terminated] to the double-quote policy that by default will make it behave the same as before the change. but if changed to 'false', it will allow '\0' inside quoted column instead of throwing exception.  2. moved no_quote_escape policy up (compiler warning). 3. cast 2 methods to int to match return type. (also compiler warning)