### PR TITLE
Remove warning about non NUL-terminated string

### DIFF
--- a/csv.h
+++ b/csv.h
@@ -75,7 +75,7 @@ namespace io{
 
                         void set_file_name(const char*file_name){
                                 if(file_name != nullptr){
-                                        strncpy(this->file_name, file_name, sizeof(this->file_name));
+                                        strncpy(this->file_name, file_name, sizeof(this->file_name)-1);
                                         this->file_name[sizeof(this->file_name)-1] = '\0';
                                 }else{
                                         this->file_name[0] = '\0';


### PR DESCRIPTION
Even thou the code take care to actually override the last by byte of the buffer with '\0' null character, gcc v8 and v9 still complain about it because strncpy(buf, str, buflen) is used rather than strncpy(buf, str, buflen - 1). See strcpy(3) for more details.

The removed warning was:

```
In function ‘char* strncpy(char*, const char*, size_t)’,
    inlined from ‘void io::LineReader::set_file_name(const char*)’ at ../../src/fast-cpp-csv-parser/csv.h:425:40,
    inlined from ‘io::LineReader::LineReader(const char*, std::istream&)’ at ../../src/fast-cpp-csv-parser/csv.h:410:38,
    inlined from ‘io::CSVReader<column_count, trim_policy, quote_policy, overflow_policy, comment_policy>::CSVReader(Args&& ...) [with Args = {const char* const&, std::basic_istream<char, std::char_traits<char> >&}; unsigned int column_count = 10; trim_policy = io::trim_chars<' ', '\011'>; quote_policy = io::double_quote_escape<',', '\"'>; overflow_policy = io::throw_on_overflow; comment_policy = io::single_line_comment<'#', ';'>]’ at ../../src/fast-cpp-csv-parser/csv.h:1137:81:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:106:34: warning: ‘char* __builtin_strncpy(char*, const char*, long unsigned int)’ specified bound 256 equals destination size [-Wstringop-truncation]
  106 |   return __builtin___strncpy_chk (__dest, __src, __len, __bos (__dest));
      |          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```