### PR TITLE
Add necessary <limits> include when CSV_IO_NO_THREAD is defined.

### DIFF
--- a/csv.h
+++ b/csv.h
@@ -48,6 +48,7 @@
 #include <cassert>
 #include <cerrno>
 #include <istream>
+#include <limits>
 
 namespace io{
         ////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
If CSV_IO_NO_THREAD is defined the limits header is not indirectly included.

Tested with:
``` c++
#define CSV_IO_NO_THREAD
#include "csv.h"

int main() { return 0; }
```