### PR TITLE
Add fuzzing by way of ClusterFuzzLite

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+
+COPY . $SRC/fast-cpp-csv-parser
+COPY .clusterfuzzlite/build.sh $SRC/build.sh
+WORKDIR $SRC/fast-cpp-csv-parser

--- a/.clusterfuzzlite/README.md
+++ b/.clusterfuzzlite/README.md
@@ -1,0 +1,4 @@
+# ClusterFuzzLite set up
+
+This folder contains a fuzzing set for [ClusterFuzzLite](https://google.github.io/clusterfuzzlite).
+        

--- a/.clusterfuzzlite/README.md
+++ b/.clusterfuzzlite/README.md
@@ -1,4 +1,19 @@
 # ClusterFuzzLite set up
 
 This folder contains a fuzzing set for [ClusterFuzzLite](https://google.github.io/clusterfuzzlite).
-        
+
+## Running fuzzing locally
+
+To reproduce this set up the way ClusterFuzzLite does it (by way of [OSS-Fuzz](https://github.com/google/oss)) you can do:
+
+```sh
+git clone https://github.com/google/oss-fuzz
+git clone https://github.com/ben-strasser/fast-cpp-csv-parser
+cd fast-cpp-csv-parser
+
+# Build the fuzzers in .clusterfuzzlite
+python3 ../oss-fuzz/infra/helper.py build_fuzzers --external $PWD
+
+# Run the fuzzer for 180 seconds
+python3 ../oss-fuzz/infra/helper.py run_fuzzer --external $PWD parse_fuzzer-- -max_total_time=180
+```

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -eu
+# Supply build instructions
+# Use the following environment variables to build the code
+# $CXX:               c++ compiler
+# $CC:                c compiler
+# CFLAGS:             compiler flags for C files
+# CXXFLAGS:           compiler flags for CPP files
+# LIB_FUZZING_ENGINE: linker flag for fuzzing harnesses
+
+# Copy all fuzzer executables to $OUT/
+
+# Copy all fuzzer executables to $OUT/
+$CXX $CFLAGS $LIB_FUZZING_ENGINE \
+  $SRC/fast-cpp-csv-parser/.clusterfuzzlite/parse_fuzzer.cpp \
+  -o $OUT/parse_fuzzer \
+  -I$SRC/fast-cpp-csv-parser

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -8,9 +8,9 @@
 # LIB_FUZZING_ENGINE: linker flag for fuzzing harnesses
 
 # Copy all fuzzer executables to $OUT/
-
-# Copy all fuzzer executables to $OUT/
-$CXX $CFLAGS $LIB_FUZZING_ENGINE \
+# CXXFLAGS holds variables necessary to instrument fuzzing, e.g. saniizer and
+# fuzzing flags.
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE \
   $SRC/fast-cpp-csv-parser/.clusterfuzzlite/parse_fuzzer.cpp \
   -o $OUT/parse_fuzzer \
   -I$SRC/fast-cpp-csv-parser

--- a/.clusterfuzzlite/parse_fuzzer.cpp
+++ b/.clusterfuzzlite/parse_fuzzer.cpp
@@ -1,0 +1,27 @@
+
+#include "csv.h"
+#include <unistd.h>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+  char filename[256];
+  sprintf(filename, "/tmp/libfuzzer.%d.csv", getpid());
+  FILE *fp = fopen(filename, "wb");
+  if (!fp)
+    return 0;
+  fwrite(data, size, 1, fp);
+  fclose(fp);
+
+  io::CSVReader<3> in(filename);
+  try {
+    in.read_header(io::ignore_extra_column, "vendor", "col2", "col3");
+    std::string vendor;
+    int col2;
+    double col3;
+    while (in.read_row(vendor, col2, col3)) {
+    }
+  } catch (...) {
+  }
+
+  unlink(filename);
+  return 0;
+}

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: c++

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -2,7 +2,7 @@ name: ClusterFuzzLite PR fuzzing
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 permissions: read-all
 jobs:
   PR:

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,30 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        language: c++
+        bad-build-check: false
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 100
+        mode: 'code-change'
+        report-unreproducible-crashes: false
+        sanitizer: ${{ matrix.sanitizer }}


### PR DESCRIPTION
This adds fuzzing by way of [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/), which is a GitHub action that will perform a short amount of fuzzing for new PRs. The goal is to use fuzzing to catch bugs that may be introduced by new PRs.

I added a fuzzer that targets the reading logic and currently set the timeout of CFLite to 100 seconds. CFLite will flag if the fuzzer finds any issues in the code introduced by a PR.

To reproduce this set up the way ClusterFuzzLite does it (by way of [OSS-Fuzz](https://github.com/google/oss)) you can do:

```sh
git clone https://github.com/google/oss-fuzz
git clone https://github.com/DavidKorczynski/fast-cpp-csv-parser
cd fast-cpp-csv-parser
git checkout clusterfuzzlite

# Build the fuzzers in .clusterfuzzlite
python3 ../oss-fuzz/infra/helper.py build_fuzzers --external $PWD

# Run the fuzzer for 10 seconds
python3 ../oss-fuzz/infra/helper.py run_fuzzer --external $PWD parse_fuzzer-- -max_total_time=10
```