### PR TITLE
Avoid string truncation warning by leaving space for null terminator

### DIFF
--- a/csv.h
+++ b/csv.h
@@ -407,7 +407,7 @@ public:
 
   void set_file_name(const char *file_name) {
     if (file_name != nullptr) {
-      strncpy(this->file_name, file_name, sizeof(this->file_name));
+      strncpy(this->file_name, file_name, sizeof(this->file_name) - 1);
       this->file_name[sizeof(this->file_name) - 1] = '\0';
     } else {
       this->file_name[0] = '\0';


### PR DESCRIPTION
Removes a string truncation warning emitted by GCC-13. 

The next line sets the last byte to the null-terminator, so the strncpy is redundant. Meaning we can reduce the size of the strcpy by 1 byte. 

